### PR TITLE
Changing responses accord to Immobilienscout

### DIFF
--- a/lib/immobilienscout/api/report.rb
+++ b/lib/immobilienscout/api/report.rb
@@ -15,7 +15,7 @@ module Immobilienscout
 
         def execute_get_request(url, query_params)
           parsed_response = Immobilienscout::Request.new(url, query_params).get
-          raise Immobilienscout::Errors::InvalidRequest, parsed_response.messages.map(&:messages) unless parsed_response.success?
+          raise Immobilienscout::Errors::InvalidRequest, Array.wrap(parsed_response.messages['message']) unless parsed_response.success?
 
           parsed_response
         end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -12,16 +12,48 @@ RSpec.describe Immobilienscout::API::Report, type: :model do
 
   describe '#retrieve' do
     context 'when request is successful' do
-      let!(:is24_id) { '315270728' }
+      context 'when dates are the same' do
+        let!(:is24_id) { '315270728' }
 
-      it 'returns created' do
-        VCR.use_cassette('scout_report_generated_successfuly') do
-          response = described_class.retrieve(is24_id, Date.today, Date.today)
+        it 'returns created' do
+          VCR.use_cassette('scout_report_generated_successfuly_with_same_date') do
+            response = described_class.retrieve(is24_id, Date.today, Date.today)
 
-          expect(response.code).to eq '200'
-          expect(response.messages).to eq({"dailyReports"=>{"@objectNumber"=>"S3W0UP6C", "reportDailyData"=>[{"date"=>"2019-06-11", "matchesResultList"=>0,
-            "displaysResultList"=>0, "exposeHits"=>0, "onShortList"=>0, "clicksHomepage"=>0, "emailContacts"=>0, "clicksSendUrl"=>0, "clickFocusPlacement"=>0,
-            "showMiniExposeFocusPlacement"=>0, "displayFocusPlacement"=>0}]}})
+            expect(response.code).to eq '200'
+            expect(response.messages).to eq({"dailyReports"=>[{"date"=>"2019-06-11", "matchesResultList"=>766,
+              "displaysResultList"=>116, "exposeHits"=>5, "onShortList"=>0, "clicksHomepage"=>0, "emailContacts"=>0, "clicksSendUrl"=>0, "clickFocusPlacement"=>0,
+              "showMiniExposeFocusPlacement"=>0, "displayFocusPlacement"=>0}], "realEstateId"=>"S3W0UP6C"})
+          end
+        end
+      end
+
+      context 'when dates are a range' do
+        let!(:is24_id) { '315270728' }
+
+        it 'returns created' do
+          VCR.use_cassette('scout_report_generated_successfuly_with_range') do
+            response = described_class.retrieve(is24_id, 2.days.ago.to_date, Date.today)
+
+            expect(response.code).to eq '200'
+            expect(response.messages).to eq({"dailyReports"=>[{"date"=>"2019-06-10", "matchesResultList"=>776,
+              "displaysResultList"=>166, "exposeHits"=>7, "onShortList"=>0, "clicksHomepage"=>0, "emailContacts"=>0, "clicksSendUrl"=>0, "clickFocusPlacement"=>0,
+              "showMiniExposeFocusPlacement"=>0, "displayFocusPlacement"=>0}, {"date"=>"2019-06-11", "matchesResultList"=>766,
+              "displaysResultList"=>116, "exposeHits"=>5, "onShortList"=>0, "clicksHomepage"=>0, "emailContacts"=>0, "clicksSendUrl"=>0, "clickFocusPlacement"=>0,
+              "showMiniExposeFocusPlacement"=>0, "displayFocusPlacement"=>0}], "realEstateId"=>"S3W0UP6C"})
+          end
+        end
+      end
+
+      context 'when dates does not have data' do
+        let!(:is24_id) { '112715859' }
+
+        it 'returns created' do
+          VCR.use_cassette('scout_report_generated_successfuly_with_no_data') do
+            response = described_class.retrieve(is24_id, Date.today, Date.today)
+
+            expect(response.code).to eq '200'
+            expect(response.messages).to eq({"dailyReports"=>[], "realEstateId"=>"22AOIMOP"})
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ require 'dotenv'
 Dotenv.load
 
 require 'immobilienscout'
-
+require 'timecop'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/vcr_cassettes/date_from_is_bigger_than_date_in_scout_report.yml
+++ b/spec/vcr_cassettes/date_from_is_bigger_than_date_in_scout_report.yml
@@ -21,38 +21,24 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '210'
+      - '176'
       Connection:
       - keep-alive
-      Cache-Control:
-      - private
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      L-Is24-Requestrefnum:
-      - 979b2244-3fd6-405a-a3b8-c73540359e6f
-      L-Is24-Apiclient:
-      - 'consumer_key'
-      L-Is24-Causerid:
-      - '117533741'
-      L-Is24-Resourceid:
-      - '315270728'
       Date:
-      - Tue, 11 Jun 2019 12:27:37 GMT
-      Server:
-      - Apache
+      - Wed, 14 Aug 2019 13:31:54 GMT
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 261d871caba4097bc29b3ff8bd23af86.cloudfront.net (CloudFront)
+      - 1.1 3f146fa6bc6607097fc0d9bc7e6d4947.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - TXL51
       X-Amz-Cf-Id:
-      - e2ureHav2uChFaCdtbmZFTK7AuSvX6UtinQpY6dgEdxCe6aAGg7sFQ==
+      - GzxtGHdd5yvRrqFhQ1Y0l8pSIk5G7IOkRo5xlWHgY44tNpkH_Vl5wQ==
     body:
       encoding: UTF-8
-      string: '{"common.messages":[{"message":{"messageCode":"ERROR_COMMON_URL_PARAMETER_VALIDATION_FAILED","message":"The
+      string: '{"messageCode":"ERROR_COMMON_URL_PARAMETER_VALIDATION_FAILED","message":"The
         parameter [dateFrom = 2019-06-11 dateTo = 2019-06-10] has an invalid value
-        [Negative date range]."}}]}'
+        [Negative date range]."}'
     http_version:
-  recorded_at: Tue, 11 Jun 2019 10:00:00 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 14 Aug 2019 13:31:54 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/property_to_create_report_does_not_exist_on_is24.yml
+++ b/spec/vcr_cassettes/property_to_create_report_does_not_exist_on_is24.yml
@@ -21,35 +21,23 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '150'
+      - '115'
       Connection:
       - keep-alive
-      Cache-Control:
-      - private
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      L-Is24-Requestrefnum:
-      - 71b0115c-cba8-473c-beef-2c9d935a4f1b
-      L-Is24-Apiclient:
-      - 'consumer_key'
-      L-Is24-Causerid:
-      - '117533741'
-      L-Is24-Resourceid:
-      - thisIsNotAValidId
       Date:
-      - Tue, 11 Jun 2019 12:29:28 GMT
-      Server:
-      - Apache
+      - Wed, 14 Aug 2019 13:31:55 GMT
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 33be852abb39a8e95242a0c764cdc483.cloudfront.net (CloudFront)
+      - 1.1 27b16a0c069e2a271545e30400f5a415.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL51
       X-Amz-Cf-Id:
-      - BNcwe7-sLojHGlldoakTAbMUIwGv-1-MTCDL7JEcQvdbza6IhknE7Q==
+      - 0xSwwah6DI9R5ChgowQZimO2xdC7MxOL9V4eT7aLVAgAe7Z_PfQwpg==
     body:
       encoding: UTF-8
-      string: '{"common.messages":[{"message":{"messageCode":"ERROR_RESOURCE_NOT_FOUND","message":"Resource
-        [realestate] with id [thisIsNotAValidId] not found. "}}]}'
+      string: '{"messageCode":"ERROR_RESOURCE_NOT_FOUND","message":"Resource [realestate]
+        with id [thisIsNotAValidId] not found."}'
     http_version:
-  recorded_at: Tue, 11 Jun 2019 10:00:00 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 14 Aug 2019 13:31:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/scout_report_generated_successfuly_with_no_data.yml
+++ b/spec/vcr_cassettes/scout_report_generated_successfuly_with_no_data.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/112715859/dailyreport?dateFrom=2019-06-11&dateTo=2019-06-11
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=THDhqSKCuA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1560247200,oauth_token=access_token,oauth_version=1.0,dateFrom=2019-06-11,dateTo=2019-06-11,oauth_signature=EAAkOGrMrk6UD83mcg7wqCh6afw%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Aug 2019 13:39:40 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a3dc4a768d48247641f8ad7f08326d38.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL52-C1
+      X-Amz-Cf-Id:
+      - vh--RL61_dp0sE22IcCHaLs1oogEezLg_waWRA2aEV1iHPUVYusVag==
+    body:
+      encoding: UTF-8
+      string: '{"realEstateId":"22AOIMOP","dailyReports":[]}'
+    http_version:
+  recorded_at: Wed, 14 Aug 2019 13:39:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/scout_report_generated_successfuly_with_range.yml
+++ b/spec/vcr_cassettes/scout_report_generated_successfuly_with_range.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/315270728/dailyreport?dateFrom=2019-06-09&dateTo=2019-06-11
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=THDhqSKCuA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1560247200,oauth_token=access_token,oauth_version=1.0,dateFrom=2019-06-09,dateTo=2019-06-11,oauth_signature=EAAkOGrMrk6UD83mcg7wqCh6afw%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '524'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Aug 2019 13:31:54 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c53e057b6a5ef86fdf09ac1341f7b843.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL51
+      X-Amz-Cf-Id:
+      - tqdSKE2Inj7movDnGGzOETBfK98ZJkKMxJh4FrS--qW5WXrH1cYSMQ==
+    body:
+      encoding: UTF-8
+      string: '{"realEstateId":"S3W0UP6C","dailyReports":[{"date":"2019-06-10","matchesResultList":776,"displaysResultList":166,"exposeHits":7,"onShortList":0,"clicksHomepage":0,"emailContacts":0,"clicksSendUrl":0,"clickFocusPlacement":0,"showMiniExposeFocusPlacement":0,"displayFocusPlacement":0},{"date":"2019-06-11","matchesResultList":766,"displaysResultList":116,"exposeHits":5,"onShortList":0,"clicksHomepage":0,"emailContacts":0,"clicksSendUrl":0,"clickFocusPlacement":0,"showMiniExposeFocusPlacement":0,"displayFocusPlacement":0}]}'
+    http_version:
+  recorded_at: Wed, 14 Aug 2019 13:31:54 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/scout_report_generated_successfuly_with_same_date.yml
+++ b/spec/vcr_cassettes/scout_report_generated_successfuly_with_same_date.yml
@@ -21,36 +21,22 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '301'
+      - '284'
       Connection:
       - keep-alive
-      Cache-Control:
-      - private
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      L-Is24-Requestrefnum:
-      - 3ced33fa-f4f7-4a55-8c9e-ac81e73a64da
-      L-Is24-Apiclient:
-      - 'consumer_key'
-      L-Is24-Causerid:
-      - '117533741'
-      L-Is24-Resourceid:
-      - '315270728'
       Date:
-      - Tue, 11 Jun 2019 12:27:03 GMT
-      Server:
-      - Apache
+      - Wed, 14 Aug 2019 13:31:53 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 342c9b6ea7230889a22dcc532c1d3136.cloudfront.net (CloudFront)
+      - 1.1 261d871caba4097bc29b3ff8bd23af86.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - TXL51
       X-Amz-Cf-Id:
-      - x4DYLoxn30X7uhLMobbsU9hoqyoNbHE1O0ZkY78C5Heatk7sKPDy8Q==
+      - oeGun1fKp8mo9mU27x3Fbwx6GhFo9p_MDmCaaaMbnLmOZqLD_m_ZMQ==
     body:
       encoding: UTF-8
-      string: '{"dailyReports":{"@objectNumber":"S3W0UP6C","reportDailyData":[{"date":"2019-06-11","matchesResultList":0,"displaysResultList":0,"exposeHits":0,"onShortList":0,"clicksHomepage":0,"emailContacts":0,"clicksSendUrl":0,"clickFocusPlacement":0,"showMiniExposeFocusPlacement":0,"displayFocusPlacement":0}]}}'
+      string: '{"realEstateId":"S3W0UP6C","dailyReports":[{"date":"2019-06-11","matchesResultList":766,"displaysResultList":116,"exposeHits":5,"onShortList":0,"clicksHomepage":0,"emailContacts":0,"clicksSendUrl":0,"clickFocusPlacement":0,"showMiniExposeFocusPlacement":0,"displayFocusPlacement":0}]}'
     http_version:
-  recorded_at: Tue, 11 Jun 2019 10:00:00 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 14 Aug 2019 13:31:53 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Immobilienscout has decided to leave his ScoutReport response as `JSON` but they changed the structure of the response, from 
```
{"dailyReports"=>{"@objectNumber"=>"S3W0UP6C", "reportDailyData"=>[{"da...
```
to
```
 {"dailyReports"=>[{"date"=>"201...=>0}], "realEstateId"=>"S3W0UP6C"}
```
and the error responses doesn't come in an array anymore, that's why the `Array.wrap(parsed_response.messages['message'])`

The cassettes were updated and two more tests cases were added, when `dates are a range` and `dates do not have data`, in this last case is returning empty array (BTW that's new too, previously they were returning the dates with the items set in zero).