### PR TITLE
Support the Property show endpoint

### DIFF
--- a/lib/immobilienscout/api/property.rb
+++ b/lib/immobilienscout/api/property.rb
@@ -22,6 +22,14 @@ module Immobilienscout
           execute_delete_request(destroy_url)
         end
 
+        def show(is24_id)
+          raise ArgumentError unless is24_id.present?
+
+          show_url = show_url(is24_id)
+
+          execute_get_request(show_url)
+        end
+
         private
 
         def execute_post_request(url, params)
@@ -38,6 +46,13 @@ module Immobilienscout
           parsed_response
         end
 
+        def execute_get_request(url)
+          parsed_response = Immobilienscout::Request.new(url).get
+          raise Immobilienscout::Errors::InvalidRequest, parsed_response.messages.map(&:messages) unless parsed_response.success?
+
+          parsed_response
+        end
+
         def create_url
           "#{Immobilienscout::Client.api_url}/restapi/api/offer/v1.0/user/me/realestate"
         end
@@ -47,6 +62,10 @@ module Immobilienscout
         end
 
         def destroy_url(is24_id)
+          "#{Immobilienscout::Client.api_url}/restapi/api/offer/v1.0/user/me/realestate/#{is24_id}"
+        end
+
+        def show_url(is24_id)
           "#{Immobilienscout::Client.api_url}/restapi/api/offer/v1.0/user/me/realestate/#{is24_id}"
         end
       end

--- a/lib/immobilienscout/request.rb
+++ b/lib/immobilienscout/request.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 module Immobilienscout
   class Request
-    def initialize(url, params = nil)
+    def initialize(url, params = {})
       @url = url
       @params = params
 

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Immobilienscout::API::Property, type: :model do
           expect(parsed_response.code).to eq '200'
           expect(parsed_response.messages['realestates.apartmentBuy']['@id']).to eq('315661708')
           expect(parsed_response.messages['realestates.apartmentBuy']['externalId']).to eq('extID123')
+          expect(parsed_response.messages['realestates.apartmentBuy']['realEstateState']).to eq('ACTIVE')
         end
       end
     end
@@ -174,6 +175,7 @@ RSpec.describe Immobilienscout::API::Property, type: :model do
           expect(parsed_response.code).to eq '200'
           expect(parsed_response.messages['realestates.apartmentBuy']['@id']).to eq('315661713')
           expect(parsed_response.messages['realestates.apartmentBuy']['externalId']).to eq('extID123INACTIVE')
+          expect(parsed_response.messages['realestates.apartmentBuy']['realEstateState']).to eq('INACTIVE')
         end
       end
     end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -150,4 +150,42 @@ RSpec.describe Immobilienscout::API::Property, type: :model do
       end
     end
   end
+
+  describe '#show' do
+    context 'when object exists and is active' do
+      it 'returns the resource' do
+        VCR.use_cassette('active_property_successfully_retrieved', decode_compressed_response: true) do
+          parsed_response = described_class.show('315661708')
+          expect(parsed_response.is_a?(Struct)).to eq true
+          expect(parsed_response.success?).to eq true
+          expect(parsed_response.code).to eq '200'
+          expect(parsed_response.messages['realestates.apartmentBuy']['@id']).to eq('315661708')
+          expect(parsed_response.messages['realestates.apartmentBuy']['externalId']).to eq('extID123')
+        end
+      end
+    end
+
+    context 'when object exists and is in-active' do
+      it 'returns the resource' do
+        VCR.use_cassette('inactive_property_successfully_retrieved') do
+          parsed_response = described_class.show('315661713')
+          expect(parsed_response.is_a?(Struct)).to eq true
+          expect(parsed_response.success?).to eq true
+          expect(parsed_response.code).to eq '200'
+          expect(parsed_response.messages['realestates.apartmentBuy']['@id']).to eq('315661713')
+          expect(parsed_response.messages['realestates.apartmentBuy']['externalId']).to eq('extID123INACTIVE')
+        end
+      end
+    end
+
+    context 'when object does not exist' do
+      it 'returns the resource' do
+        VCR.use_cassette('property_to_show_does_not_exist') do
+          expect { described_class.show('000000000') }.to raise_exception(Immobilienscout::Errors::InvalidRequest) { |exception|
+            expect(exception.message).to eq('["Resource was not found."]')
+          }
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,9 @@ RSpec.configure do |config|
   # VCR cassetes config
   VCR.configure do |config|
     config.cassette_library_dir = 'spec/vcr_cassettes'
+    config.before_record do |i|
+      i.response.body.force_encoding('UTF-8')
+    end
     config.hook_into :webmock
     config.ignore_localhost = true
   end

--- a/spec/vcr_cassettes/active_property_successfully_retrieved.yml
+++ b/spec/vcr_cassettes/active_property_successfully_retrieved.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/315661708
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=myHomedayKey,oauth_nonce=HdfNwSJQ,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1580834887,oauth_token=f7677b9c-c52a-4101-b736-26e8f0e4e898,oauth_version=1.0,oauth_signature=Ki4KnWbVL7sLCFbPGjfWbZqJrvw%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2590'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 04 Feb 2020 16:48:08 GMT
+      L-Is24-Requestrefnum:
+      - e80621b1-d18e-41e9-8b1c-376c820f5685
+      L-Is24-Apiclient:
+      - myHomedayKey
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - '315661708'
+      Etag:
+      - '"05d4c0096573831b68ce82d96ad713089"'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8a8ce1b655547c1da36b64e17700f010.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL52-C1
+      X-Amz-Cf-Id:
+      - Ra2Wwqvs1eriUwtBePbtVFqzwEQYVm-oqm0e2vSK7UOt5HMsJuRHfw==
+    body:
+      encoding: UTF-8
+      string: '{"realestates.apartmentBuy":{"@id":"315661708","externalId":"extID123","title":"RestAPi
+        appartmentBuy","creationDate":"2020-02-04T15:57:00.096Z","address":{"street":"Andreasstraße","houseNumber":"10","postcode":"10243","city":"Berlin","wgs84Coordinate":{"latitude":52.51245,"longitude":13.43134},"geoHierarchy":{"continent":{"geoCodeId":1,"fullGeoCodeId":"1"},"country":{"geoCodeId":276,"fullGeoCodeId":"1276"},"region":{"geoCodeId":3,"fullGeoCodeId":"1276003"},"city":{"geoCodeId":1,"fullGeoCodeId":"1276003001"},"quarter":{"geoCodeId":17,"fullGeoCodeId":"1276003001017"},"neighbourhood":{"geoCodeId":11000000002348}}},"apiSearchData":{"searchField1":"apiSearchField1","searchField2":"apiSearchField2","searchField3":"apiSearchField3"},"realEstateState":"ACTIVE","descriptionNote":"Objektbeschreibung(noch
+        2000 Zeichen) description-note \\n after line break this text is in the next
+        row","furnishingNote":"Ausstattung(noch 2000 Zeichen)","locationNote":"Lage(noch
+        2000 Zeichen)","otherNote":"Sonstiges(noch 2000 Zeichen)","attachments":[{"@xlink.href":"https:\/\/rest.sandbox-immobilienscout24.de\/restapi\/api\/offer\/v1.0\/user\/me\/realestate\/315661708\/attachment"}],"showAddress":"true","contact":{"@id":"96701088"},"common.publishChannels":[{"publishChannel":{"@id":"10000","@title":"ImmobilienScout24"}}],"apartmentType":"MAISONETTE","floor":2,"lift":"true","energyCertificate":{"energyCertificateAvailability":"AVAILABLE","energyCertificateCreationDate":"BEFORE_01_MAY_2014"},"cellar":"YES","handicappedAccessible":"YES","numberOfParkingSpaces":1,"condition":"WELL_KEPT","lastRefurbishment":2010,"interiorQuality":"SOPHISTICATED","constructionYear":1995,"freeFrom":"sofort","heatingTypeEnev2014":"FLOOR_HEATING","firingTypes":[{"firingType":"NO_INFORMATION"}],"energySourcesEnev2014":{"energySourceEnev2014":"WOOD_CHIPS"},"buildingEnergyRatingType":"ENERGY_CONSUMPTION","thermalCharacteristic":123.85,"energyConsumptionContainsWarmWater":"YES","numberOfFloors":5,"usableFloorSpace":70,"numberOfBedRooms":1,"numberOfBathRooms":2,"guestToilet":"YES","parkingSpaceType":"UNDERGROUND_GARAGE","rented":"YES","rentalIncome":895,"listed":"YES","parkingSpacePrice":15000,"summerResidencePractical":"YES","price":{"value":175000,"currency":"EUR","marketingType":"PURCHASE","priceIntervalType":"ONE_TIME_CHARGE"},"livingSpace":75,"numberOfRooms":3,"energyPerformanceCertificate":"true","builtInKitchen":"true","balcony":"true","garden":"true","courtage":{"hasCourtage":"YES","courtage":"Provisionshöhe
+        (brutto)","courtageNote":"Provisionshinweis (noch 500 Zeichen)"},"serviceCharge":575}}'
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 16:48:08 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr_cassettes/inactive_property_successfully_retrieved.yml
+++ b/spec/vcr_cassettes/inactive_property_successfully_retrieved.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/315661713
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=myHomedayKey,oauth_nonce=wRNhJLAsIA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1580834888,oauth_token=f7677b9c-c52a-4101-b736-26e8f0e4e898,oauth_version=1.0,oauth_signature=xyzvpwVwMNwXCzZBVDKKKtbWJ8s%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2537'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 04 Feb 2020 16:48:09 GMT
+      L-Is24-Requestrefnum:
+      - 7ee40cbc-bbe3-4da6-bed4-21fa175e1573
+      L-Is24-Apiclient:
+      - myHomedayKey
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - '315661713'
+      Etag:
+      - '"0bc535026a762b1cfd5c9cf165bb977f9"'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ffa01f5c992a803f4470401daea2d541.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL52-C1
+      X-Amz-Cf-Id:
+      - e9sxHpTJQ6RYNxlV7SWI_PsIJ38e6dKwJXO9aPmi-Hl15t71rym1XQ==
+    body:
+      encoding: UTF-8
+      string: '{"realestates.apartmentBuy":{"@id":"315661713","externalId":"extID123INACTIVE","title":"RestAPi
+        appartmentBuy","creationDate":"2020-02-04T16:03:18.569Z","address":{"street":"Andreasstraße","houseNumber":"10","postcode":"10243","city":"Berlin","wgs84Coordinate":{"latitude":52.51245,"longitude":13.43134},"geoHierarchy":{"continent":{"geoCodeId":1,"fullGeoCodeId":"1"},"country":{"geoCodeId":276,"fullGeoCodeId":"1276"},"region":{"geoCodeId":3,"fullGeoCodeId":"1276003"},"city":{"geoCodeId":1,"fullGeoCodeId":"1276003001"},"quarter":{"geoCodeId":17,"fullGeoCodeId":"1276003001017"},"neighbourhood":{"geoCodeId":11000000002348}}},"apiSearchData":{"searchField1":"apiSearchField1","searchField2":"apiSearchField2","searchField3":"apiSearchField3"},"realEstateState":"INACTIVE","descriptionNote":"Objektbeschreibung(noch
+        2000 Zeichen) description-note \\n after line break this text is in the next
+        row","furnishingNote":"Ausstattung(noch 2000 Zeichen)","locationNote":"Lage(noch
+        2000 Zeichen)","otherNote":"Sonstiges(noch 2000 Zeichen)","attachments":[{"@xlink.href":"https:\/\/rest.sandbox-immobilienscout24.de\/restapi\/api\/offer\/v1.0\/user\/me\/realestate\/315661713\/attachment"}],"showAddress":"true","contact":{"@id":"96701088"},"common.publishChannels":[],"apartmentType":"MAISONETTE","floor":2,"lift":"true","energyCertificate":{"energyCertificateAvailability":"AVAILABLE","energyCertificateCreationDate":"BEFORE_01_MAY_2014"},"cellar":"YES","handicappedAccessible":"YES","numberOfParkingSpaces":1,"condition":"WELL_KEPT","lastRefurbishment":2010,"interiorQuality":"SOPHISTICATED","constructionYear":1995,"freeFrom":"sofort","heatingTypeEnev2014":"FLOOR_HEATING","firingTypes":[{"firingType":"NO_INFORMATION"}],"energySourcesEnev2014":{"energySourceEnev2014":"WOOD_CHIPS"},"buildingEnergyRatingType":"ENERGY_CONSUMPTION","thermalCharacteristic":123.85,"energyConsumptionContainsWarmWater":"YES","numberOfFloors":5,"usableFloorSpace":70,"numberOfBedRooms":1,"numberOfBathRooms":2,"guestToilet":"YES","parkingSpaceType":"UNDERGROUND_GARAGE","rented":"YES","rentalIncome":895,"listed":"YES","parkingSpacePrice":15000,"summerResidencePractical":"YES","price":{"value":175000,"currency":"EUR","marketingType":"PURCHASE","priceIntervalType":"ONE_TIME_CHARGE"},"livingSpace":75,"numberOfRooms":3,"energyPerformanceCertificate":"true","builtInKitchen":"true","balcony":"true","garden":"true","courtage":{"hasCourtage":"YES","courtage":"Provisionshöhe
+        (brutto)","courtageNote":"Provisionshinweis (noch 500 Zeichen)"},"serviceCharge":575}}'
+    http_version: 
+  recorded_at: Tue, 04 Feb 2020 16:48:09 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr_cassettes/property_to_show_does_not_exist.yml
+++ b/spec/vcr_cassettes/property_to_show_does_not_exist.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/000000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=myHomedayKey,oauth_nonce=1ap3MnSmmw,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1580918888,oauth_token=f7677b9c-c52a-4101-b736-26e8f0e4e898,oauth_version=1.0,oauth_signature=8WZKfpeut6upZYIy9oriQR35Fm4%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 05 Feb 2020 16:08:09 GMT
+      L-Is24-Requestrefnum:
+      - cb63b17d-ffd9-4c7e-8afc-ab221cad1904
+      L-Is24-Apiclient:
+      - myHomedayKey
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - '000000000'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 aec69d2871c7aeb74988020f07480fa4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL52-C1
+      X-Amz-Cf-Id:
+      - w8oXEViC6uOLniSATFrVrs8nGDzjQSKqqsOwwq4zz4IX1xOtYkhRIw==
+    body:
+      encoding: UTF-8
+      string: '{"common.messages":[{"message":{"messageCode":"ERROR_RESOURCE_NOT_FOUND","message":"Resource
+        was not found."}}]}'
+    http_version: 
+  recorded_at: Wed, 05 Feb 2020 16:08:08 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
Adds support for this endpoint: https://api.immobilienscout24.de/api-docs/import-export/real-estate/retrieve-real-estate-by-id/