### PR TITLE
Add retrieve_all and destroy action for attachments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ rvm:
   - 2.6.5
 script:
   - bundle exec rubocop
+  - bundle exec rspec
+
 before_install: gem install bundler -v 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.8] - 2020-07-16
+* Added retrieve_all endpoint to attachments to retrieve all attachments of a property
+* Added destroy endpoint to attachments to destroy an attachment of a property
 
 ## [0.0.7] - 2020-03-30
 * Improve error handling. Catching a `InvalidRequest` error still works, but now

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    immobilienscout (0.0.8)
+    immobilienscout (0.0.7)
       activesupport
       json
       multipart-post
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.2)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -23,11 +23,11 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (1.0.1)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    json (2.3.0)
-    minitest (5.14.0)
+    json (2.3.1)
+    minitest (5.14.1)
     multipart-post (2.1.1)
     parallel (1.19.1)
     parser (2.7.0.5)
@@ -65,7 +65,7 @@ GEM
     safe_yaml (1.0.5)
     thread_safe (0.3.6)
     timecop (0.8.1)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
     vcr (5.1.0)
@@ -91,4 +91,4 @@ DEPENDENCIES
   webmock (~> 3.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    immobilienscout (0.0.7)
+    immobilienscout (0.0.8)
       activesupport
       json
       multipart-post

--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ Immobilienscout::API::Property.publish({params})
 Immobilienscout::API::Property.update(is24_id, {params})
 ```
 
-  _Note: You have to send all attributes, also if only one attribute has changed. Otherwise Immobilienscout cannot interpret if a missing attribute should be filled in with NULL or not._
+_Notes:_
+
+You have to send all attributes, also if only one attribute has changed. Otherwise Immobilienscout cannot interpret if a missing attribute should be filled in with NULL or not.
+
+`is24_id` is the id returned by Immobilienscout when you first created the property.
+
+If you have provided a custom id, you can use `"ext-#{custom_id}"` instead of the is24_id.
+
 
 - Delete property
 ```ruby
@@ -58,6 +65,16 @@ Immobilienscout::API::Attachment.add(is24_id, binary_file, {metadata})
  - Order attachments for a specific property
 ```ruby
 Immobilienscout::API::Attachment.put_order(is24_id, {params})
+```
+
+ - Retrieve all attachments for a specific property
+```ruby
+Immobilienscout::API::Attachment.retrieve_all(is24_id)
+```
+
+ - Delete an attachment for a specific property
+```ruby
+Immobilienscout::API::Attachment.destroy(is24_id, attachment_id)
 ```
 
 #### Report

--- a/lib/immobilienscout/api/attachment.rb
+++ b/lib/immobilienscout/api/attachment.rb
@@ -30,6 +30,27 @@ module Immobilienscout
           parsed_response
         end
 
+        def retrieve_all(is24_id)
+          raise ArgumentError unless is24_id.present?
+
+          url = retrieve_all_url(is24_id)
+          parsed_response = Immobilienscout::Request.new(url).get
+          Immobilienscout::RequestErrorHandler.handle(parsed_response) unless parsed_response.success?
+
+          parsed_response
+        end
+
+        def destroy(is24_id, attachment_id)
+          raise ArgumentError unless is24_id.present?
+          raise ArgumentError unless attachment_id.present?
+
+          url = destroy_url(is24_id, attachment_id)
+          parsed_response = Immobilienscout::Request.new(url).delete
+          Immobilienscout::RequestErrorHandler.handle(parsed_response) unless parsed_response.success?
+
+          parsed_response
+        end
+
         private
 
         def create_metadata_file(params)
@@ -44,6 +65,16 @@ module Immobilienscout
         def put_order_url(is24_id)
           "#{Immobilienscout::Client.api_url}/restapi/api/"\
           "offer/v1.0/user/me/realestate/#{is24_id}/attachment/attachmentsorder"
+        end
+
+        def retrieve_all_url(is24_id)
+          "#{Immobilienscout::Client.api_url}/restapi/api/"\
+          "offer/v1.0/user/me/realestate/#{is24_id}/attachment"
+        end
+
+        def destroy_url(is24_id, attachment_id)
+          "#{Immobilienscout::Client.api_url}/restapi/api/"\
+          "offer/v1.0/user/me/realestate/#{is24_id}/attachment/#{attachment_id}"
         end
       end
     end

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -113,6 +113,27 @@ RSpec.describe Immobilienscout::API::Attachment, type: :class do
         end
       end
     end
+
+    context 'when a property exists and has no attachments' do
+      it 'returns the resource' do
+        VCR.use_cassette('attachment_retrieve_all_without_attachemnts') do
+          parsed_response = described_class.retrieve_all('315920212')
+          expect(parsed_response.is_a?(Struct)).to eq true
+          expect(parsed_response.success?).to eq true
+          expect(parsed_response.code).to eq '200'
+
+          expect(parsed_response['messages']['common.attachments'].size).to eq(0)
+        end
+      end
+    end
+
+    context 'when a property does not exist' do
+      it 'returns not found' do
+        VCR.use_cassette('attachment_property_does_not_exist') do
+          expect { described_class.retrieve_all('000000000') }.to raise_exception(Immobilienscout::Errors::ResourceNotFound)
+        end
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/vcr_cassettes/attachment_property_does_not_exist.yml
+++ b/spec/vcr_cassettes/attachment_property_does_not_exist.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/000000000/attachment
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=nonce,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1552567703,oauth_token=access_token,oauth_version=1.0,oauth_signature=foo
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 16 Jul 2020 10:42:58 GMT
+      L-Is24-Requestrefnum:
+      - cee21946-4c58-4397-aff2-45981763c848
+      L-Is24-Apiclient:
+      - myHomedayKey
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - '000000000'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 9d11c99c18949c4780bf1400ceca8369.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - TXL52-C1
+      X-Amz-Cf-Id:
+      - vR4I_s2vAju_CJsjGz_LJGpKQ8jfLsEFLV-N3bQfqQjvnbzDiZqzpQ==
+    body:
+      encoding: UTF-8
+      string: '{"common.messages":[{"message":{"messageCode":"ERROR_RESOURCE_NOT_FOUND","message":"Resource
+        was not found."}}]}'
+    http_version: null
+  recorded_at: Thu, 16 Jul 2020 10:42:58 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/attachment_retrieve_all.yml
+++ b/spec/vcr_cassettes/attachment_retrieve_all.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/ext-D1TGDF9V/attachment
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=LYiEWxQUuA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1560263360,oauth_token=access_token,oauth_version=1.0,oauth_signature=DZd9mD1Esy87NVjfJbDiA%2Fc5FTA%3D
+
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4863'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 14 Jul 2020 21:43:40 GMT
+      L-Is24-Requestrefnum:
+      - f25f1ae9-063e-4943-aa92-b2f4fce8887a
+      L-Is24-Apiclient:
+      - consumer_key
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - ext-D1TGDF9V
+      Etag:
+      - '"0f47bea0eb29247095d6bb61a04d1c55a"'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c80802be222c215cc6dc681294b37eb8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - CDG50-C1
+      X-Amz-Cf-Id:
+      - "-ePFgpRr9ZjhG9bRg_zmauUKskfsITzt4SQ7X8wAsyFTmuifSdjCcw=="
+    body:
+      encoding: UTF-8
+      string: '{"common.attachments":[{"attachment":[{"@xsi.type":"common:Picture","@xlink.href":"https:\/\/rest.sandbox-immobilienscout24.de\/restapi\/api\/offer\/v1.0\/user\/me\/realestate\/ext-D1TGDF9V\/attachment\/897494197","@id":"897494197","@modification":"2020-07-14T15:41:04.305Z","title":"Homeday
+        Prozess","externalId":"homeday_process_is24.png","externalCheckSum":"c68ad44b93928c9531e14269924d8390","floorplan":"false","titlePicture":"true","urls":[{"url":[{"@scale":"SCALE","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/%WIDTH%x%HEIGHT%>\/format\/jpg"},{"@scale":"SCALE_AND_CROP","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/legacy_thumbnail\/%WIDTH%x%HEIGHT%\/format\/jpg"},{"@scale":"WHITE_FILLING","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/%WIDTH%x%HEIGHT%>\/extent\/%WIDTH%x%HEIGHT%\/format\/jpg"},{"@scale":"SCALE_540x540","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/540x540>\/format\/jpg"},{"@scale":"SCALE_210x210","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/210x210>\/format\/jpg"},{"@scale":"SCALE_400x300","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/400x300>\/format\/jpg"},{"@scale":"SCALE_118x118","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/118x118>\/extent\/118x118\/format\/jpg"},{"@scale":"SCALE_60x60","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/60x60>\/extent\/60x60\/format\/jpg"},{"@scale":"SCALE_73x73","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/legacy_thumbnail\/73x73\/format\/jpg"},{"@scale":"SCALE_1000x1000","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/63e388aa-17b2-4a40-b875-7bdb31777b72-897494197.png\/ORIG\/resize\/1000x1000>\/format\/jpg"}]}]},{"@xsi.type":"common:Picture","@xlink.href":"https:\/\/rest.sandbox-immobilienscout24.de\/restapi\/api\/offer\/v1.0\/user\/me\/realestate\/ext-D1TGDF9V\/attachment\/897494198","@id":"897494198","@modification":"2020-07-14T15:41:04.957Z","title":"Ihre
+        Immobilie verkaufen?","externalId":"homeday_service_advertisement.png","externalCheckSum":"3d744dfd8d5a53d8c3dedae18d548733","floorplan":"false","titlePicture":"false","urls":[{"url":[{"@scale":"SCALE","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/%WIDTH%x%HEIGHT%>\/format\/jpg"},{"@scale":"SCALE_AND_CROP","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/legacy_thumbnail\/%WIDTH%x%HEIGHT%\/format\/jpg"},{"@scale":"WHITE_FILLING","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/%WIDTH%x%HEIGHT%>\/extent\/%WIDTH%x%HEIGHT%\/format\/jpg"},{"@scale":"SCALE_540x540","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/540x540>\/format\/jpg"},{"@scale":"SCALE_210x210","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/210x210>\/format\/jpg"},{"@scale":"SCALE_400x300","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/400x300>\/format\/jpg"},{"@scale":"SCALE_118x118","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/118x118>\/extent\/118x118\/format\/jpg"},{"@scale":"SCALE_60x60","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/60x60>\/extent\/60x60\/format\/jpg"},{"@scale":"SCALE_73x73","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/legacy_thumbnail\/73x73\/format\/jpg"},{"@scale":"SCALE_1000x1000","@href":"https:\/\/pictures.sandbox-immobilienscout24.de\/listings-test\/4c3d9ea9-2a5d-4e83-96ba-91dd0f1ced6d-897494198.png\/ORIG\/resize\/1000x1000>\/format\/jpg"}]}]}]}]}'
+    http_version: null
+  recorded_at: Tue, 14 Jul 2020 21:43:40 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/attachment_retrieve_all_without_attachemnts.yml
+++ b/spec/vcr_cassettes/attachment_retrieve_all_without_attachemnts.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/315920212/attachment
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=nonce,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1552567703,oauth_token=access_token,oauth_version=1.0,oauth_signature=foo
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '25'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 16 Jul 2020 10:39:58 GMT
+      L-Is24-Requestrefnum:
+      - 066a1379-f23c-47d8-b2af-cd64c6a1aee3
+      L-Is24-Apiclient:
+      - myHomedayKey
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - '315920212'
+      Etag:
+      - '"04de8e9ad2afcccef41485efa78d3161f"'
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c34e5d6ab957cd4e49caca604410ca40.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ATL56-C1
+      X-Amz-Cf-Id:
+      - 0BsVxwcna-god8kXIy1oqzHMMx4JTJRahC_UbjoaS5Qi0_PHyeyJ4g==
+    body:
+      encoding: UTF-8
+      string: '{"common.attachments":[]}'
+    http_version: null
+  recorded_at: Thu, 16 Jul 2020 10:39:58 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/attachment_successfully_deleted.yml
+++ b/spec/vcr_cassettes/attachment_successfully_deleted.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/ext-D1TGDF9V/attachment/897494196
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=LYiEWxQUuA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1560263360,oauth_token=access_token,oauth_version=1.0,oauth_signature=DZd9mD1Esy87NVjfJbDiA%2Fc5FTA%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '165'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 14 Jul 2020 21:41:03 GMT
+      L-Is24-Requestrefnum:
+      - dc21bfb7-16b0-4839-9f83-fa79fba342f8
+      L-Is24-Apiclient:
+      - consumer_key
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - ext-D1TGDF9V
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8d84df16ba20ff1d2ca3914948494e04.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - FRA54
+      X-Amz-Cf-Id:
+      - e7i60NxYdNhryNAk6LQVoiCwrFVhfzvn-7zQnn1ReJQDKc7Nacs3gQ==
+    body:
+      encoding: UTF-8
+      string: '{"common.messages":[{"message":{"messageCode":"MESSAGE_RESOURCE_DELETED","message":"Resource
+        [attachment] with id [897494196] has been deleted.","id":"897494196"}}]}'
+    http_version: null
+  recorded_at: Tue, 14 Jul 2020 21:41:03 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/attachment_to_delete_does_not_exist_on_is24.yml
+++ b/spec/vcr_cassettes/attachment_to_delete_does_not_exist_on_is24.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://rest.sandbox-immobilienscout24.de/restapi/api/offer/v1.0/user/me/realestate/ext-D1TGDF9V/attachment/00000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - OAuth oauth_consumer_key=consumer_key,oauth_nonce=LYiEWxQUuA,oauth_signature_method=HMAC-SHA1,oauth_timestamp=1560263360,oauth_token=access_token,oauth_version=1.0,oauth_signature=DZd9mD1Esy87NVjfJbDiA%2Fc5FTA%3D
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 14 Jul 2020 21:56:38 GMT
+      L-Is24-Requestrefnum:
+      - 34f59f8f-522f-4b7e-8ce7-2ab856520a2e
+      L-Is24-Apiclient:
+      - consumer_key
+      L-Is24-Causerid:
+      - '121920857'
+      L-Is24-Resourceid:
+      - ext-D1TGDF9V
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 6e8dd39e00d9a5c1a31d69ffa2821a5e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - FRA54
+      X-Amz-Cf-Id:
+      - zvZatYg3N2htHEZccHorZEmNvCltKr84hIsRqe0yqLo4eOupxKDz3A==
+    body:
+      encoding: UTF-8
+      string: '{"common.messages":[{"message":{"messageCode":"ERROR_RESOURCE_NOT_FOUND","message":"Resource
+        was not found."}}]}'
+    http_version: null
+  recorded_at: Tue, 14 Jul 2020 21:56:38 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
When a property gets updated, existing pictures are kept. In order to update a picture, the picture first needs to be deleted. To support this, the following two methods have been added:

- Retrieve all attachments for a specific property
```ruby
Immobilienscout::API::Attachment.retrieve_all(is24_id)
```

This returns the attachment ids required for the destroy call.

 - Delete an attachment for a specific property
```ruby
Immobilienscout::API::Attachment.destroy(is24_id, attachment_id)
```
